### PR TITLE
Fix fresh-clone onboarding: setup flow, docs, and startup noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JavaDropbox
 
-> A lightweight, self-hosted file management solution built with Java and Spring Boot. Access, manage, and download your files from anywhere.
+> A lightweight, self-hosted file management solution built with Spring Boot and React. Access, manage, and download your files from anywhere.
 
 JavaDropbox is designed for:
 - **Developers and IT professionals** who want a private, self-hosted solution for managing project files or internal documentation.
@@ -16,95 +16,136 @@ In short, the main audience consists of users who value **control, security, and
     -   Download individual files directly.
     -   Download entire folders, which are automatically zipped on-the-fly.
 -   **Uploads:** Easily add files by dragging them into the browser or using a traditional file selector.
+-   **Folder Management:** Create new folders and navigate nested directories from the UI.
+-   **File Versioning & History:** Track changes to files and view their history (backed by PostgreSQL).
 -   **Configurable Directory:** Serve files from the default `JDB` subfolder or specify any directory on your system via a command-line argument.
--   **Springboot Security:** Authentication to restrict access to the file management interface.
+-   **Spring Security:** Single-admin authentication to restrict access to the file management interface.
 
-##  Tech Stack
+## Tech Stack
 
 -   **Backend:**
-    -   Java 21+
-    -   Spring Boot 3+ (Spring Web)
-    -   Thymeleaf
-    -   Spring Security
+    -   Java 21
+    -   Spring Boot 3.5 (Spring Web, Spring Security, Spring Data JPA, Spring Modulith)
+    -   PostgreSQL 15
 -   **Frontend:**
-    -   HTML5
-    -   CSS3 
-    -   Vanilla JavaScript (ES6+)
--   **Build Tool:**
-    -   Gradle
+    -   React 19 + Vite
+    -   Redux Toolkit, React Router
+    -   Tailwind CSS, axios
+-   **Build / Tooling:**
+    -   Gradle (wrapper included)
+    -   Docker (for the PostgreSQL database)
 
-##  Getting Started
+## Architecture
+
+The backend is a Spring Boot application that exposes a JSON API (under `/api`) plus
+`/setup`, `/login`, and `/logout` endpoints. The frontend is a separate React single-page
+app served by Vite during development, which proxies API/auth requests to the backend.
+File metadata, versions, and the single admin user are stored in PostgreSQL; the actual
+files live on disk in the configured serving directory (default: `./JDB`).
+
+## Getting Started
 
 Follow these instructions to get a local copy up and running.
 
 ### Prerequisites
 
-You must have a Java Development Kit (JDK) installed on your system.
--   [JDK Version 21 or higher](https://www.oracle.com/java/technologies/downloads/)
+-   **JDK 21** ([Temurin](https://adoptium.net/) or equivalent)
+-   **Docker** (Docker Desktop or compatible) — used to run PostgreSQL. The backend
+    auto-starts the database via Spring Boot's Docker Compose support, so Docker must be
+    running before you start the backend.
+-   **Node.js 20+** and npm — for the frontend.
 
-### Installation & Running
+### 1. Clone the repository
 
-1.  **Clone the repository:**
-    ```bash
-    git clone https://github.com/mevcaus/JavaDropBox.git
-    cd JavaDropBox
-    ```
+```bash
+git clone https://github.com/mevcaus/JavaDropbox.git
+cd JavaDropbox
+```
 
-2.  **Build the project:**
-    Use the Gradle wrapper to build the application. This will download all necessary dependencies.
-    ```bash
-    ./gradlew build
-    ```
+### 2. Run the backend (and database)
 
-3.  **Run the application:**
-    You have two options for running the server.
+The backend reads [`compose.yaml`](compose.yaml) and automatically starts a PostgreSQL
+container on first launch (via the `spring-boot-docker-compose` integration), so you do
+**not** need to start the database manually.
 
-    **Option A: Default Mode**
-    This will automatically create and serve files from a folder named `JDB` inside your project directory.
-    ```bash
-    ./gradlew bootRun
-    ```
+```bash
+./gradlew bootRun
+```
 
-    **Option B: Custom Directory Mode**
-    Use the `--args` flag to specify an absolute path to any directory you want to serve.
-    ```bash
-    ./gradlew bootRun --args='--directory=/path/to/your/files'
-    ```
-    *Example for Windows:*
-    ```powershell
-    ./gradlew bootRun --args='--directory=C:\Users\YourUser\Documents'
-    ```
+This starts the API on **http://localhost:8080** and creates/serves files from a `JDB`
+folder in the project directory.
 
-##  How to Use
+**Custom serving directory** — pass an absolute path to serve any directory:
 
-### Accessing the Web UI
+```bash
+./gradlew bootRun --args='--directory=/path/to/your/files'
+```
 
-1.  Once the server is running, open your web browser and navigate to:
-    **`http://localhost:8080`**
+> If you prefer to run PostgreSQL yourself instead of via Docker, start it with the
+> credentials in [`compose.yaml`](compose.yaml) (db `javadropbox`, user `postgres`,
+> password `password`, port `5432`) — these match
+> [`src/main/resources/application.properties`](src/main/resources/application.properties).
 
-2.  Upon first access it will ask you to setup a username and password for authentication.
+### 3. Run the frontend
 
-3.  After setting up your credentials, you will be redirected to the login screen. Use the credentials you just created to log in.
+In a second terminal:
 
+```bash
+cd frontend
+npm install
+npm run dev
+```
 
-> note: if you forget your credentials, you can delete the `users.properties` file located in the project directory to reset them.
+This starts the React app on **http://localhost:5173** and proxies API/auth calls to the
+backend on port 8080.
+
+## How to Use
+
+### First-time setup
+
+1.  With both servers running, open **http://localhost:5173**.
+2.  On the login screen, click **"Need to setup a first user?"** to open the setup page.
+3.  Create an admin username and password. You'll be redirected to the login screen.
+4.  Log in with the credentials you just created.
+
+> **Resetting credentials:** the admin account is stored in the `users` table in
+> PostgreSQL. To start over, either clear that table
+> (`TRUNCATE users RESTART IDENTITY CASCADE;`) or wipe the database volume entirely with
+> `docker compose down -v`. After that, the setup flow will be available again.
 
 ### Core Functionality
 
--   **Downloading:** Click directly on the name of any file or folder to start the download. Folders will be downloaded as a `.zip` file.
--   **Uploading:** Click the "Add Files" button. A modal will appear where you can either drag and drop files or click "Select Files" to open your system's file explorer.
--   **Deleting:** Click the trash can icon (🗑️) on the right side of any file or folder row. A confirmation pop-up will appear to prevent accidental deletion.
+-   **Downloading:** Click directly on the name of any file or folder to start the download. Folders are downloaded as a `.zip` file.
+-   **Uploading:** Click the "Add Files" button to drag and drop files or open your system's file explorer.
+-   **Creating folders:** Use the new-folder action to create empty directories.
+-   **Deleting:** Click the trash can icon (🗑️) on any row. A confirmation pop-up prevents accidental deletion.
+
+## Building for Production
+
+```bash
+# Backend: produces an executable jar in build/libs/
+./gradlew build
+
+# Frontend: produces static assets in frontend/dist/
+cd frontend && npm run build
+```
+
+## Running the Tests
+
+```bash
+./gradlew test
+```
+
+Tests run against an in-memory H2 database, so they do **not** require Docker or
+PostgreSQL.
 
 ## Future Enhancements
 
-Future plans for this project include:
 -   [ ] **File Previews:** Implement previews for common file types (images, PDFs, text files).
 -   [ ] **Search Functionality:** Add a search bar to quickly locate files and folders.
 -   [ ] **Sorting Options:** Allow users to sort files and folders by name, date, size, etc.
 -   [ ] **Upload to Subfolders:** Allow users to upload files directly into the currently expanded folder.
--   [ ] **Upload entire folders:** Allow users to upload folders directly into the currently expanded folder.
--   [ ] **Create New Folders:** Add a UI element to create new, empty directories.
--   [ ] **Desktop Folder Integration:** Create a desktop folder functionality that syncs a local folder with the server.
+-   [ ] **Desktop Folder Integration:** Sync a local folder with the server.
 
 ## License
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,16 +1,48 @@
-# React + Vite
+# JavaDropbox — Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+The React + Vite single-page app for [JavaDropbox](../README.md). It talks to the Spring
+Boot backend through Vite's dev proxy.
 
-Currently, two official plugins are available:
+## Stack
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- React 19 + Vite
+- Redux Toolkit (state) and React Router (routing)
+- Tailwind CSS (styling)
+- axios (HTTP)
 
-## React Compiler
+## Prerequisites
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+- Node.js 20+ and npm
+- The backend running on **http://localhost:8080** (see the [root README](../README.md))
 
-## Expanding the ESLint configuration
+## Development
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+```bash
+npm install
+npm run dev
+```
+
+The app runs on **http://localhost:5173**. Vite proxies `/api`, `/setup`, `/login`, and
+`/logout` to the backend on port 8080 (see [`vite.config.js`](vite.config.js)), so make
+sure the backend is running first.
+
+## Available scripts
+
+| Script            | Description                            |
+| ----------------- | -------------------------------------- |
+| `npm run dev`     | Start the Vite dev server with HMR.    |
+| `npm run build`   | Build production assets into `dist/`.  |
+| `npm run preview` | Preview the production build locally.  |
+| `npm run lint`    | Run ESLint over the project.           |
+
+## Project structure
+
+```
+src/
+  components/   Reusable UI components (modals, tables, navbar, sidebar)
+  features/     Redux slices (auth, files)
+  layouts/      Shared page layout(s)
+  pages/        Route-level pages (Login, Setup, Dashboard)
+  services/     axios instance and API helpers
+  redux/        Store configuration
+```

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import MainLayout from './layouts/MainLayout';
 import Login from './pages/Login';
+import Setup from './pages/Setup';
 import Dashboard from './pages/Dashboard';
 
 // Placeholder for Dashboard until implemented
@@ -11,6 +12,7 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/login" element={<Login />} />
+        <Route path="/setup" element={<Setup />} />
 
         <Route path="/" element={<MainLayout />}>
           <Route index element={<Navigate to="/dashboard" replace />} />

--- a/frontend/src/pages/Setup.jsx
+++ b/frontend/src/pages/Setup.jsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import api from '../services/api';
+import { HardDrive, Loader2 } from 'lucide-react';
+
+const Setup = () => {
+    const [username, setUsername] = useState('');
+    const [password, setPassword] = useState('');
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const navigate = useNavigate();
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+
+        try {
+            // The backend /setup endpoint expects x-www-form-urlencoded params.
+            const params = new URLSearchParams();
+            params.append('username', username);
+            params.append('password', password);
+
+            await api.post('/setup', params, {
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            });
+
+            // Account created — send the user to the login screen.
+            navigate('/login', { replace: true });
+        } catch (err) {
+            const message =
+                err.response?.data?.error ||
+                err.response?.data?.message ||
+                'Setup failed. An account may already exist.';
+            setError(message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+            <div className="max-w-md w-full space-y-8">
+                <div className="text-center">
+                    <div className="mx-auto h-12 w-12 flex items-center justify-center rounded-full bg-blue-100">
+                        <HardDrive className="h-8 w-8 text-blue-600" />
+                    </div>
+                    <h2 className="mt-6 text-3xl font-extrabold text-gray-900">Create your admin account</h2>
+                    <p className="mt-2 text-sm text-gray-600">
+                        This is a one-time setup for your JavaDropbox instance.
+                    </p>
+                </div>
+                <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+                    <div className="rounded-md shadow-sm -space-y-px">
+                        <div>
+                            <label htmlFor="username" className="sr-only">Username</label>
+                            <input
+                                id="username"
+                                name="username"
+                                type="text"
+                                required
+                                className="
+                                    appearance-none rounded-none rounded-t-md relative block w-full
+                                    px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900
+                                    focus:outline-none focus:ring-blue-500 focus:border-blue-500
+                                    focus:z-10 sm:text-sm
+                                "
+                                placeholder="Username"
+                                value={username}
+                                onChange={(e) => setUsername(e.target.value)}
+                            />
+                        </div>
+                        <div>
+                            <label htmlFor="password" className="sr-only">Password</label>
+                            <input
+                                id="password"
+                                name="password"
+                                type="password"
+                                required
+                                className="
+                                    appearance-none rounded-none rounded-b-md relative block w-full
+                                    px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900
+                                    focus:outline-none focus:ring-blue-500 focus:border-blue-500
+                                    focus:z-10 sm:text-sm
+                                "
+                                placeholder="Password"
+                                value={password}
+                                onChange={(e) => setPassword(e.target.value)}
+                            />
+                        </div>
+                    </div>
+
+                    {error && (
+                        <div className="text-red-500 text-sm text-center">
+                            {typeof error === 'string' ? error : 'Setup failed'}
+                        </div>
+                    )}
+
+                    <div>
+                        <button
+                            type="submit"
+                            disabled={loading}
+                            className="
+                                group relative w-full flex justify-center py-2 px-4
+                                border border-transparent text-sm font-medium rounded-md
+                                text-white bg-blue-600 hover:bg-blue-700
+                                focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500
+                                disabled:opacity-50
+                            "
+                        >
+                            {loading ? (
+                                <Loader2 className="animate-spin h-5 w-5 text-white" />
+                            ) : (
+                                "Create account"
+                            )}
+                        </button>
+                    </div>
+                    <div className="text-center">
+                        <Link to="/login" className="font-medium text-blue-600 hover:text-blue-500 text-sm">
+                            Already have an account? Sign in
+                        </Link>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+};
+
+export default Setup;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -21,6 +21,14 @@ export default defineConfig({
           });
         },
       },
+      '/setup': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        secure: false,
+        // Only the POST that creates the admin account goes to the backend.
+        // GET /setup is a client-side route, so let Vite serve the SPA.
+        bypass: (req) => (req.method !== 'POST' ? '/index.html' : undefined),
+      },
       '/login': {
         target: 'http://localhost:8080',
         changeOrigin: true,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,5 +7,4 @@ spring.datasource.username=postgres
 spring.datasource.password=password
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-logging.level.org.springframework.security=DEBUG
+logging.level.org.springframework.security=INFO


### PR DESCRIPTION
## Summary
Fixes the issues that block a fresh clone from actually running end-to-end:

- closes #45 — first-run setup page/route was missing, so there was no way to create the first admin account from the UI
- closes #46 — README described an old stack (Thymeleaf/vanilla JS) instead of the actual Spring Boot + PostgreSQL backend / React+Vite frontend
- closes #47 — frontend README was still the default create-vite template
- closes #48 — redundant Hibernate dialect property and DEBUG security logging cluttering every boot

## Test plan
- [x] `./gradlew build` and `./gradlew test` pass locally
- [x] Frontend `npm run build` passes
- [x] Manually verified setup → login → file listing flow end-to-end against a real Postgres instance