### PR TITLE
Time-limited share links

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.h2database:h2'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 

--- a/frontend/src/components/FileTable.jsx
+++ b/frontend/src/components/FileTable.jsx
@@ -1,4 +1,4 @@
-import { File, Folder, Download, Trash2, FileText, Image, Film, Music } from 'lucide-react';
+import { File, Folder, Download, Share2, Trash2, FileText, Image, Film, Music } from 'lucide-react';
 
 const FileIcon = ({ type, name }) => {
     if (type === 'DIRECTORY') return <Folder className="h-5 w-5 text-blue-500" />;
@@ -28,7 +28,7 @@ const formatSize = (bytes) => {
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
 };
 
-const FileTable = ({ files, onDelete, onDownload, onFolderClick }) => {
+const FileTable = ({ files, onDelete, onDownload, onShare, onFolderClick }) => {
     if (!files || files.length === 0) {
         return <div className="text-center py-10 text-gray-500">No files found.</div>;
     }
@@ -106,6 +106,16 @@ const FileTable = ({ files, onDelete, onDownload, onFolderClick }) => {
                                     title="Download"
                                 >
                                     <Download className="h-5 w-5" />
+                                </button>
+                                <button
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        onShare(file);
+                                    }}
+                                    className="text-blue-600 hover:text-blue-900 mr-4"
+                                    title="Share"
+                                >
+                                    <Share2 className="h-5 w-5" />
                                 </button>
                                 <button
                                     onClick={(e) => {

--- a/frontend/src/components/ShareModal.jsx
+++ b/frontend/src/components/ShareModal.jsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from 'react';
+import { Link2, Copy, Check, Loader2 } from 'lucide-react';
+import api from '../services/api';
+
+const EXPIRATION_OPTIONS = [
+    { label: '15 minutes', minutes: 15 },
+    { label: '1 hour', minutes: 60 },
+    { label: '24 hours', minutes: 60 * 24 },
+    { label: '7 days', minutes: 60 * 24 * 7 },
+];
+
+const ShareModal = ({ isOpen, onClose, item }) => {
+    const [expirationMinutes, setExpirationMinutes] = useState(EXPIRATION_OPTIONS[2].minutes);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [shareUrl, setShareUrl] = useState(null);
+    const [copied, setCopied] = useState(false);
+
+    // Reset state whenever a new item is shared
+    useEffect(() => {
+        setShareUrl(null);
+        setError(null);
+        setCopied(false);
+        setExpirationMinutes(EXPIRATION_OPTIONS[2].minutes);
+    }, [item]);
+
+    if (!isOpen || !item) return null;
+
+    const handleGenerate = async () => {
+        setLoading(true);
+        setError(null);
+
+        try {
+            const params = new URLSearchParams();
+            params.append('path', item.path);
+            params.append('expirationMinutes', expirationMinutes);
+
+            const response = await api.post('/api/share', params, {
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            });
+
+            setShareUrl(response.data.url);
+        } catch (err) {
+            setError(err.response?.data?.message || 'Failed to create share link.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleCopy = async () => {
+        if (!shareUrl) return;
+        await navigator.clipboard.writeText(shareUrl);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+            <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+                <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true" onClick={onClose}></div>
+
+                <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+                <div className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
+                    <div className="sm:flex sm:items-start">
+                        <div className="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-blue-100 sm:mx-0 sm:h-10 sm:w-10">
+                            <Link2 className="h-6 w-6 text-blue-600" aria-hidden="true" />
+                        </div>
+                        <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left w-full">
+                            <h3 className="text-lg leading-6 font-medium text-gray-900" id="modal-title">
+                                Share <span className="font-semibold">{item.name}</span>
+                            </h3>
+
+                            {!shareUrl ? (
+                                <div className="mt-4 space-y-4">
+                                    <div>
+                                        <label htmlFor="expiration" className="block text-sm font-medium text-gray-700 mb-1">
+                                            Link expires in
+                                        </label>
+                                        <select
+                                            id="expiration"
+                                            value={expirationMinutes}
+                                            onChange={(e) => setExpirationMinutes(Number(e.target.value))}
+                                            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm py-2 px-3 border"
+                                        >
+                                            {EXPIRATION_OPTIONS.map((opt) => (
+                                                <option key={opt.minutes} value={opt.minutes}>
+                                                    {opt.label}
+                                                </option>
+                                            ))}
+                                        </select>
+                                    </div>
+                                    <p className="text-sm text-gray-500">
+                                        Anyone with the link can download this {item.isDirectory ? 'folder' : 'file'} until it expires. No account is required.
+                                    </p>
+                                    {error && <p className="text-sm text-red-500">{error}</p>}
+                                </div>
+                            ) : (
+                                <div className="mt-4 space-y-3">
+                                    <div className="flex items-center gap-2">
+                                        <input
+                                            type="text"
+                                            readOnly
+                                            value={shareUrl}
+                                            className="block w-full rounded-md border-gray-300 shadow-sm bg-gray-50 text-sm py-2 px-3 border"
+                                            onFocus={(e) => e.target.select()}
+                                        />
+                                        <button
+                                            type="button"
+                                            onClick={handleCopy}
+                                            className="flex-shrink-0 inline-flex items-center justify-center p-2 rounded-md border border-gray-300 text-gray-600 hover:bg-gray-50"
+                                            title="Copy link"
+                                        >
+                                            {copied ? <Check className="h-5 w-5 text-green-600" /> : <Copy className="h-5 w-5" />}
+                                        </button>
+                                    </div>
+                                    <p className="text-sm text-gray-500">
+                                        This link expires in {EXPIRATION_OPTIONS.find((o) => o.minutes === expirationMinutes)?.label || `${expirationMinutes} minutes`}.
+                                    </p>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                    <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+                        {!shareUrl ? (
+                            <button
+                                type="button"
+                                disabled={loading}
+                                className="w-full inline-flex justify-center items-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-blue-600 text-base font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
+                                onClick={handleGenerate}
+                            >
+                                {loading ? <Loader2 className="animate-spin h-5 w-5" /> : 'Generate link'}
+                            </button>
+                        ) : null}
+                        <button
+                            type="button"
+                            className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm"
+                            onClick={onClose}
+                        >
+                            {shareUrl ? 'Done' : 'Cancel'}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ShareModal;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -6,6 +6,7 @@ import Breadcrumbs from '../components/Breadcrumbs';
 import DeleteConfirmationModal from '../components/DeleteConfirmationModal';
 import CreateFolderModal from '../components/CreateFolderModal';
 import InfoModal from '../components/InfoModal';
+import ShareModal from '../components/ShareModal';
 import { Loader2, FolderPlus, ChevronDown, Upload as UploadIcon, HardDrive as HardDriveIcon, File as FileIcon } from 'lucide-react';
 import api from '../services/api';
 
@@ -18,6 +19,8 @@ const Dashboard = () => {
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [itemToDelete, setItemToDelete] = useState(null);
     const [isCreateFolderModalOpen, setIsCreateFolderModalOpen] = useState(false);
+    const [isShareModalOpen, setIsShareModalOpen] = useState(false);
+    const [itemToShare, setItemToShare] = useState(null);
     const [isUploadDropdownOpen, setIsUploadDropdownOpen] = useState(false);
     // State for info modal
     const [infoModalState, setInfoModalState] = useState({ isOpen: false, title: '', message: '' });
@@ -89,6 +92,12 @@ const Dashboard = () => {
             // alert('Download failed');
             setInfoModalState({ isOpen: true, title: 'Error', message: 'Download failed. Please try again.' });
         }
+    };
+
+    const handleShare = (file) => {
+        const path = file.relativePath || (currentPath ? `${currentPath}/${file.name}` : file.name);
+        setItemToShare({ name: file.name, isDirectory: file.isDirectory, path });
+        setIsShareModalOpen(true);
     };
 
     const showFeatureNotImplemented = (featureName) => {
@@ -191,6 +200,7 @@ const Dashboard = () => {
                 files={files}
                 onDelete={confirmDelete}
                 onDownload={handleDownload}
+                onShare={handleShare}
                 onFolderClick={handleFolderClick}
             />
 
@@ -212,6 +222,12 @@ const Dashboard = () => {
                 isOpen={isCreateFolderModalOpen}
                 onClose={() => setIsCreateFolderModalOpen(false)}
                 onCreate={handleExecuteCreateFolder}
+            />
+
+            <ShareModal
+                isOpen={isShareModalOpen}
+                onClose={() => setIsShareModalOpen(false)}
+                item={itemToShare}
             />
         </div>
     );

--- a/src/main/java/com/javadropbox/javadropbox/config/SecurityConfig.java
+++ b/src/main/java/com/javadropbox/javadropbox/config/SecurityConfig.java
@@ -54,9 +54,8 @@ public class SecurityConfig {
                                                 .requestMatchers(
                                                                 "/setup",
                                                                 "/login",
-                                                                "/setup",
-                                                                "/login",
-                                                                "/error")
+                                                                "/error",
+                                                                "/share/**")
                                                 .permitAll()
                                                 .anyRequest()
                                                 .authenticated())

--- a/src/main/java/com/javadropbox/javadropbox/controller/ShareController.java
+++ b/src/main/java/com/javadropbox/javadropbox/controller/ShareController.java
@@ -1,0 +1,87 @@
+package com.javadropbox.javadropbox.controller;
+
+import com.javadropbox.javadropbox.dto.DownloadableResource;
+import com.javadropbox.javadropbox.service.FileServingService;
+import com.javadropbox.javadropbox.service.ShareTokenService;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Time-limited share links. {@code POST /api/share} requires the normal session
+ * auth (covered by SecurityConfig's default rule). {@code GET /share/{token}} is
+ * public &mdash; it is explicitly permitted in SecurityConfig because the whole
+ * point is that someone without an account can use the link.
+ */
+@RestController
+public class ShareController {
+
+    private static final long DEFAULT_EXPIRATION_MINUTES = 24 * 60;
+    private static final long MAX_EXPIRATION_MINUTES = 7 * 24 * 60;
+
+    private final ShareTokenService shareTokenService;
+    private final FileServingService fileServingService;
+
+    public ShareController(ShareTokenService shareTokenService, FileServingService fileServingService) {
+        this.shareTokenService = shareTokenService;
+        this.fileServingService = fileServingService;
+    }
+
+    @PostMapping("/api/share")
+    public ResponseEntity<?> createShareLink(
+            @RequestParam String path,
+            @RequestParam(defaultValue = "" + DEFAULT_EXPIRATION_MINUTES) long expirationMinutes,
+            HttpServletRequest request) {
+
+        if (expirationMinutes <= 0 || expirationMinutes > MAX_EXPIRATION_MINUTES) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("message", "expirationMinutes must be between 1 and " + MAX_EXPIRATION_MINUTES));
+        }
+
+        if (!fileServingService.pathExists(path)) {
+            return ResponseEntity.notFound().build();
+        }
+
+        String token = shareTokenService.generateToken(path, expirationMinutes);
+        String shareUrl = ServletUriComponentsBuilder.fromRequestUri(request)
+                .replacePath("/share/" + token)
+                .replaceQuery(null)
+                .build()
+                .toUriString();
+
+        return ResponseEntity.ok(Map.of(
+                "url", shareUrl,
+                "expiresAt", Instant.now().plus(Duration.ofMinutes(expirationMinutes)).toString()));
+    }
+
+    @GetMapping("/share/{token}")
+    public ResponseEntity<Resource> downloadSharedFile(@PathVariable String token) {
+        String path;
+        try {
+            path = shareTokenService.resolvePath(token);
+        } catch (JwtException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        try {
+            DownloadableResource downloadable = fileServingService.getResourceForPath(path);
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType(downloadable.contentType()))
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + downloadable.filename() + "\"")
+                    .body(downloadable.resource());
+        } catch (IOException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/src/main/java/com/javadropbox/javadropbox/service/FileServingService.java
+++ b/src/main/java/com/javadropbox/javadropbox/service/FileServingService.java
@@ -254,6 +254,16 @@ public class FileServingService {
         }
     }
 
+    public boolean pathExists(String relativePath) {
+        try {
+            Path fullPath = getServingDirectoryPath().resolve(relativePath).normalize();
+            validatePathSecurity(fullPath, relativePath);
+            return Files.exists(fullPath);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
     public DownloadableResource getResourceForPath(String relativePath) throws IOException {
         Path rootPath = getServingDirectoryPath();
         Path fullPath = rootPath.resolve(relativePath).normalize();

--- a/src/main/java/com/javadropbox/javadropbox/service/ShareTokenService.java
+++ b/src/main/java/com/javadropbox/javadropbox/service/ShareTokenService.java
@@ -1,0 +1,56 @@
+package com.javadropbox.javadropbox.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Date;
+
+/**
+ * Signs and validates the JWTs used by public share links. The token's only
+ * claim is the relative path being shared, so anyone holding a valid token
+ * can download that one path until it expires &mdash; no server-side state
+ * is kept.
+ */
+@Service
+public class ShareTokenService {
+
+    private static final String PATH_CLAIM = "path";
+
+    private final SecretKey signingKey;
+
+    public ShareTokenService(@Value("${app.share.jwt-secret}") String secret) {
+        this.signingKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret));
+    }
+
+    public String generateToken(String relativePath, long expirationMinutes) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + Duration.ofMinutes(expirationMinutes).toMillis());
+
+        return Jwts.builder()
+                .claim(PATH_CLAIM, relativePath)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(signingKey)
+                .compact();
+    }
+
+    /**
+     * @throws JwtException if the token is malformed, tampered with, or expired
+     */
+    public String resolvePath(String token) throws JwtException {
+        Claims claims = Jwts.parser()
+                .verifyWith(signingKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return claims.get(PATH_CLAIM, String.class);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,9 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 logging.level.org.springframework.security=DEBUG
+
+# Signing key for share-link JWTs (HMAC-SHA256, base64-encoded, 256-bit).
+# This is a dev-only default checked into source control. Override it with
+# the APP_SHARE_JWT_SECRET env var (or app.share.jwt-secret) in any real
+# deployment, the same way you would for the DB password above.
+app.share.jwt-secret=+mRVZIlDlrnSQTcLyt3WtDhDgkceY5VMzD9D1a5CvyM=

--- a/src/test/java/com/javadropbox/javadropbox/ShareLinkIntegrationTests.java
+++ b/src/test/java/com/javadropbox/javadropbox/ShareLinkIntegrationTests.java
@@ -1,0 +1,134 @@
+package com.javadropbox.javadropbox;
+
+import com.javadropbox.javadropbox.model.User;
+import com.javadropbox.javadropbox.repository.UserRepository;
+import com.javadropbox.javadropbox.service.ShareTokenService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "app.setup.required=false",
+        "app.setup.filter.enabled=true"
+})
+@DisplayName("Share Link Integration Tests")
+class ShareLinkIntegrationTests {
+
+    @TempDir
+    static Path servingDir;
+
+    @DynamicPropertySource
+    static void overrideServingDirectory(DynamicPropertyRegistry registry) {
+        registry.add("javadropbox.serving.directory", () -> servingDir.toString());
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ShareTokenService shareTokenService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        if (userRepository.count() == 0) {
+            userRepository.save(new User("testadmin", passwordEncoder.encode("password"), "ROLE_ADMIN"));
+        }
+        Files.writeString(servingDir.resolve("shared.txt"), "share me");
+    }
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("Unauthenticated user cannot create a share link")
+    void unauthenticatedCannotCreateShareLink() throws Exception {
+        mockMvc.perform(post("/api/share").param("path", "shared.txt"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Authenticated user can create a share link for an existing file")
+    @WithMockUser(username = "testuser", roles = { "USER" })
+    void authenticatedUserCanCreateShareLink() throws Exception {
+        mockMvc.perform(post("/api/share").param("path", "shared.txt"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.url").value(containsString("/share/")))
+                .andExpect(jsonPath("$.expiresAt").exists());
+    }
+
+    @Test
+    @DisplayName("Creating a share link for a nonexistent path returns 404")
+    @WithMockUser(username = "testuser", roles = { "USER" })
+    void shareLinkForMissingPathReturns404() throws Exception {
+        mockMvc.perform(post("/api/share").param("path", "nope.txt"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Out-of-range expiration is rejected")
+    @WithMockUser(username = "testuser", roles = { "USER" })
+    void outOfRangeExpirationRejected() throws Exception {
+        mockMvc.perform(post("/api/share").param("path", "shared.txt").param("expirationMinutes", "0"))
+                .andExpect(status().isBadRequest());
+
+        mockMvc.perform(post("/api/share").param("path", "shared.txt").param("expirationMinutes", "999999"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("A valid share link downloads the file without authentication")
+    void validTokenDownloadsWithoutAuth() throws Exception {
+        String token = shareTokenService.generateToken("shared.txt", 60);
+
+        mockMvc.perform(get("/share/" + token))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", containsString("shared.txt")))
+                .andExpect(content().string("share me"));
+    }
+
+    @Test
+    @DisplayName("An expired token is rejected")
+    void expiredTokenRejected() throws Exception {
+        String token = shareTokenService.generateToken("shared.txt", -1);
+
+        mockMvc.perform(get("/share/" + token))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("A tampered or garbage token is rejected")
+    void garbageTokenRejected() throws Exception {
+        mockMvc.perform(get("/share/not-a-real-token"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -5,3 +5,4 @@ spring.datasource.password=
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=create-drop
 app.setup.required=false
+app.share.jwt-secret=dGVzdC1vbmx5LXNlY3JldC1kby1ub3QtdXNlLWluLXByb2QtMTIzNDU2Nzg=


### PR DESCRIPTION
## Summary
Implements time-limited public share links, closing #28:

- JWT-based `ShareTokenService` signing/validating tokens that encode a relative file path + expiration (no server-side state needed)
- `POST /api/share` (authenticated) issues a link; `GET /share/{token}` (public) validates and streams the file via the existing path-traversal-safe serving logic
- Expiration capped at 7 days; link creation is rejected for paths that do not exist
- Share icon in the file table opens a modal to pick an expiration and copy the generated link

## Test plan
- [x] `./gradlew build` and `./gradlew test` pass, including 7 new integration tests covering: auth required to create a link, 404 for missing paths and out-of-range expirations, public download works with a valid token, expired/tampered tokens rejected
- [x] Frontend `npm run build` passes
- [x] Manually verified end-to-end: generated a link for a real file, downloaded it with no auth, confirmed a live expired-token rejection and a tampered-token rejection
