### PR TITLE
Add OpenAPI 3 documentation and Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ npm run dev
 
 ## API Reference
 
-All endpoints require authentication unless noted otherwise.
+All endpoints require authentication unless noted otherwise. For a live, interactive reference of all REST API endpoints, visit the [Swagger UI](http://localhost:8080/swagger-ui.html) locally while the backend is running.
 
 ### Authentication
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 }
 
 

--- a/src/main/java/com/javadropbox/javadropbox/config/SecurityConfig.java
+++ b/src/main/java/com/javadropbox/javadropbox/config/SecurityConfig.java
@@ -8,11 +8,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -20,76 +17,89 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 public class SecurityConfig {
 
-        private final SetupFilter setupFilter;
-        private final AuthService authService;
+  private final SetupFilter setupFilter;
+  private final AuthService authService;
 
-        public SecurityConfig(SetupFilter setupFilter, AuthService authService) {
-                this.setupFilter = setupFilter;
-                this.authService = authService;
-        }
+  public SecurityConfig(SetupFilter setupFilter, AuthService authService) {
+    this.setupFilter = setupFilter;
+    this.authService = authService;
+  }
 
-        @Bean
-        public UserDetailsService userDetailsService() {
-                return username -> {
-                        if (authService.isSetupRequired()) {
-                                throw new UsernameNotFoundException("Setup not completed");
-                        }
-                        return authService.getMainUser()
-                                        .filter(u -> u.getUsername().equals(username))
-                                        .map(u -> User.withUsername(u.getUsername())
-                                                        .password(u.getPassword())
-                                                        .roles("USER")
-                                                        .build())
-                                        .orElseThrow(() -> new UsernameNotFoundException("User not found"));
-                };
-        }
+  @Bean
+  public UserDetailsService userDetailsService() {
+    return username -> {
+      if (authService.isSetupRequired()) {
+        throw new UsernameNotFoundException("Setup not completed");
+      }
+      return authService
+          .getMainUser()
+          .filter(u -> u.getUsername().equals(username))
+          .map(
+              u ->
+                  User.withUsername(u.getUsername())
+                      .password(u.getPassword())
+                      .roles("USER")
+                      .build())
+          .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    };
+  }
 
-        @Bean
-        public SecurityFilterChain securityFilterChain(HttpSecurity http)
-                        throws Exception {
-                http
-                                .addFilterBefore(setupFilter, UsernamePasswordAuthenticationFilter.class)
-                                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                                .authorizeHttpRequests(auth -> auth
-                                                .requestMatchers(
-                                                                "/setup",
-                                                                "/login",
-                                                                "/error",
-                                                                "/share/**")
-                                                .permitAll()
-                                                .anyRequest()
-                                                .authenticated())
-                                .exceptionHandling(ex -> ex
-                                                .authenticationEntryPoint(
-                                                                new org.springframework.security.web.authentication.HttpStatusEntryPoint(
-                                                                                org.springframework.http.HttpStatus.UNAUTHORIZED)))
-                                .formLogin(form -> form
-                                                .loginProcessingUrl("/login")
-                                                .successHandler((req, res, auth) -> res.setStatus(200))
-                                                .failureHandler((req, res, exc) -> res.setStatus(401))
-                                                .permitAll())
-                                .rememberMe(rememberMe -> rememberMe
-                                                .key(UUID.randomUUID().toString())
-                                                .tokenValiditySeconds(60))
-                                .logout(logout -> logout
-                                                .logoutUrl("/logout")
-                                                .logoutSuccessHandler((req, res, auth) -> res.setStatus(200))
-                                                .permitAll())
-                                // -- DO NOT DO THIS IN PRODUCTION --
-                                .csrf(AbstractHttpConfigurer::disable);
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.addFilterBefore(setupFilter, UsernamePasswordAuthenticationFilter.class)
+        .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(
+                        "/setup",
+                        "/login",
+                        "/error",
+                        "/share/**",
+                        // Allow access to Swagger UI and OpenAPI docs without authentication in dev
+                        "/swagger-ui.html",
+                        "/swagger-ui/**",
+                        "/v3/api-docs",
+                        "/v3/api-docs/**")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
+        .exceptionHandling(
+            ex ->
+                ex.authenticationEntryPoint(
+                    new org.springframework.security.web.authentication.HttpStatusEntryPoint(
+                        org.springframework.http.HttpStatus.UNAUTHORIZED)))
+        .formLogin(
+            form ->
+                form.loginProcessingUrl("/login")
+                    .successHandler((req, res, auth) -> res.setStatus(200))
+                    .failureHandler((req, res, exc) -> res.setStatus(401))
+                    .permitAll())
+        .rememberMe(
+            rememberMe -> rememberMe.key(UUID.randomUUID().toString()).tokenValiditySeconds(60))
+        .logout(
+            logout ->
+                logout
+                    .logoutUrl("/logout")
+                    .logoutSuccessHandler((req, res, auth) -> res.setStatus(200))
+                    .permitAll())
+        // -- DO NOT DO THIS IN PRODUCTION --
+        .csrf(AbstractHttpConfigurer::disable);
 
-                return http.build();
-        }
+    return http.build();
+  }
 
-        @Bean
-        public org.springframework.web.cors.CorsConfigurationSource corsConfigurationSource() {
-                org.springframework.web.cors.CorsConfiguration configuration = new org.springframework.web.cors.CorsConfiguration();
-                configuration.setAllowedOrigins(java.util.List.of("http://localhost:5173", "http://localhost:5174"));
-                configuration.setAllowedMethods(java.util.List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-                configuration.setAllowedHeaders(java.util.List.of("*"));
-                configuration.setAllowCredentials(true);
-                org.springframework.web.cors.UrlBasedCorsConfigurationSource source = new org.springframework.web.cors.UrlBasedCorsConfigurationSource();
-                source.registerCorsConfiguration("/**", configuration);
-                return source;
-        }
+  @Bean
+  public org.springframework.web.cors.CorsConfigurationSource corsConfigurationSource() {
+    org.springframework.web.cors.CorsConfiguration configuration =
+        new org.springframework.web.cors.CorsConfiguration();
+    configuration.setAllowedOrigins(
+        java.util.List.of("http://localhost:5173", "http://localhost:5174"));
+    configuration.setAllowedMethods(java.util.List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    configuration.setAllowedHeaders(java.util.List.of("*"));
+    configuration.setAllowCredentials(true);
+    org.springframework.web.cors.UrlBasedCorsConfigurationSource source =
+        new org.springframework.web.cors.UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
+  }
 }

--- a/src/main/java/com/javadropbox/javadropbox/config/SetupFilter.java
+++ b/src/main/java/com/javadropbox/javadropbox/config/SetupFilter.java
@@ -5,54 +5,64 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-
 @Component
 @Order(1)
 public class SetupFilter extends OncePerRequestFilter {
 
-    private final AuthService authService;
+  private final AuthService authService;
 
-    // -- setup filter is ignored in test suite --
-    @Value("${app.setup.filter.enabled:true}")
-    private boolean filterEnabled;
+  // -- setup filter is ignored in test suite --
+  @Value("${app.setup.filter.enabled:true}")
+  private boolean filterEnabled;
 
-    public SetupFilter(AuthService authService) {
-        this.authService = authService;
+  public SetupFilter(AuthService authService) {
+    this.authService = authService;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    if (!filterEnabled) {
+      filterChain.doFilter(request, response);
+      return;
     }
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
+    String requestURI = request.getRequestURI();
 
-        if (!filterEnabled) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        String requestURI = request.getRequestURI();
-
-        if (authService.isSetupRequired()) {
-            if (requestURI.equals("/setup") ||
-                    requestURI.startsWith("/css/") ||
-                    requestURI.startsWith("/js/") ||
-                    requestURI.startsWith("/images/") ||
-                    requestURI.equals("/JavaDropbox_favicon.png")) {
-                filterChain.doFilter(request, response);
-            } else {
-                response.sendRedirect("/setup");
-            }
-        } else {
-            if (requestURI.equals("/setup")) {
-                response.sendRedirect("/login");
-            } else {
-                filterChain.doFilter(request, response);
-            }
-        }
+    if (authService.isSetupRequired()) {
+      if (requestURI.equals("/setup")
+          || requestURI.startsWith("/css/")
+          || requestURI.startsWith("/js/")
+          || requestURI.startsWith("/images/")
+          || requestURI.equals("/JavaDropbox_favicon.png")
+          || isApiDocsPath(requestURI)) {
+        filterChain.doFilter(request, response);
+      } else {
+        response.sendRedirect("/setup");
+      }
+    } else {
+      if (requestURI.equals("/setup")) {
+        response.sendRedirect("/login");
+      } else {
+        filterChain.doFilter(request, response);
+      }
     }
+  }
+
+  // Swagger UI and the OpenAPI spec are permitAll in SecurityConfig; exempt them here too so
+  // the API reference stays reachable before the first user is created.
+  private static boolean isApiDocsPath(String requestURI) {
+    return requestURI.equals("/swagger-ui.html")
+        || requestURI.startsWith("/swagger-ui/")
+        || requestURI.equals("/v3/api-docs")
+        || requestURI.startsWith("/v3/api-docs/");
+  }
 }

--- a/src/main/java/com/javadropbox/javadropbox/controller/FileVersionController.java
+++ b/src/main/java/com/javadropbox/javadropbox/controller/FileVersionController.java
@@ -1,64 +1,73 @@
 package com.javadropbox.javadropbox.controller;
 
 import com.javadropbox.javadropbox.dto.FileVersionDto;
-import com.javadropbox.javadropbox.model.FileMetadata;
-import com.javadropbox.javadropbox.model.FileVersion;
 import com.javadropbox.javadropbox.model.RestoreMode;
 import com.javadropbox.javadropbox.repository.FileMetadataRepository;
 import com.javadropbox.javadropbox.repository.FileVersionRepository;
 import com.javadropbox.javadropbox.service.FileServingService;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/files")
+@Tag(name = "File Versions", description = "Endpoints for managing file versions")
 public class FileVersionController {
 
-    private final FileMetadataRepository fileMetadataRepository;
-    private final FileVersionRepository fileVersionRepository;
-    private final FileServingService fileServingService;
+  private final FileMetadataRepository fileMetadataRepository;
+  private final FileVersionRepository fileVersionRepository;
+  private final FileServingService fileServingService;
 
-    public FileVersionController(FileMetadataRepository fileMetadataRepository,
-            FileVersionRepository fileVersionRepository,
-            FileServingService fileServingService) {
-        this.fileMetadataRepository = fileMetadataRepository;
-        this.fileVersionRepository = fileVersionRepository;
-        this.fileServingService = fileServingService;
-    }
+  public FileVersionController(
+      FileMetadataRepository fileMetadataRepository,
+      FileVersionRepository fileVersionRepository,
+      FileServingService fileServingService) {
+    this.fileMetadataRepository = fileMetadataRepository;
+    this.fileVersionRepository = fileVersionRepository;
+    this.fileServingService = fileServingService;
+  }
 
-    @GetMapping("/{fileId}/versions")
-    public ResponseEntity<?> getFileVersions(@PathVariable Long fileId) {
-        return fileMetadataRepository.findById(fileId)
-                .map(metadata -> {
-                    List<FileVersionDto> versions = fileVersionRepository.findByFileMetadataOrderByVersionDesc(metadata)
-                            .stream()
-                            .map(FileVersionDto::fromEntity)
-                            .collect(Collectors.toList());
-                    return ResponseEntity.ok(versions);
-                })
-                .orElse(ResponseEntity.notFound().build());
-    }
+  @GetMapping("/{fileId}/versions")
+  @Operation(
+      summary = "Get file versions",
+      description = "Returns all versions of a specific file. Requires authentication.")
+  public ResponseEntity<?> getFileVersions(@PathVariable Long fileId) {
+    return fileMetadataRepository
+        .findById(fileId)
+        .map(
+            metadata -> {
+              List<FileVersionDto> versions =
+                  fileVersionRepository.findByFileMetadataOrderByVersionDesc(metadata).stream()
+                      .map(FileVersionDto::fromEntity)
+                      .collect(Collectors.toList());
+              return ResponseEntity.ok(versions);
+            })
+        .orElse(ResponseEntity.notFound().build());
+  }
 
-    @PostMapping("/{fileId}/versions/{version}/restore")
-    public ResponseEntity<?> restoreVersion(
-            @PathVariable Long fileId,
-            @PathVariable Integer version,
-            @RequestParam(defaultValue = "OVERWRITE") RestoreMode mode) {
-        try {
-            fileServingService.restoreVersion(fileId, version, mode);
-            return ResponseEntity.ok(Map.of("message", "Version restored successfully via " + mode));
-        } catch (IOException e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(Map.of("message", "Restore failed: " + e.getMessage()));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(Map.of("message", "Restore failed: " + e.getMessage()));
-        }
+  @PostMapping("/{fileId}/versions/{version}/restore")
+  @Operation(
+      summary = "Restore file version",
+      description = "Restores a specific version of a file. Requires authentication.")
+  public ResponseEntity<?> restoreVersion(
+      @PathVariable Long fileId,
+      @PathVariable Integer version,
+      @RequestParam(defaultValue = "OVERWRITE") RestoreMode mode) {
+    try {
+      fileServingService.restoreVersion(fileId, version, mode);
+      return ResponseEntity.ok(Map.of("message", "Version restored successfully via " + mode));
+    } catch (IOException e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .body(Map.of("message", "Restore failed: " + e.getMessage()));
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+          .body(Map.of("message", "Restore failed: " + e.getMessage()));
     }
+  }
 }

--- a/src/main/java/com/javadropbox/javadropbox/controller/HistoryApi.java
+++ b/src/main/java/com/javadropbox/javadropbox/controller/HistoryApi.java
@@ -1,30 +1,33 @@
 package com.javadropbox.javadropbox.controller;
 
 import com.javadropbox.javadropbox.dto.FileHistoryDto;
-import com.javadropbox.javadropbox.model.FileHistory;
 import com.javadropbox.javadropbox.repository.FileHistoryRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api")
+@Tag(name = "History", description = "Endpoints for viewing file history")
 public class HistoryApi {
 
-    private final FileHistoryRepository fileHistoryRepository;
+  private final FileHistoryRepository fileHistoryRepository;
 
-    public HistoryApi(FileHistoryRepository fileHistoryRepository) {
-        this.fileHistoryRepository = fileHistoryRepository;
-    }
+  public HistoryApi(FileHistoryRepository fileHistoryRepository) {
+    this.fileHistoryRepository = fileHistoryRepository;
+  }
 
-    @GetMapping("/history")
-    public List<FileHistoryDto> getHistory() {
-        return fileHistoryRepository.findAll(Sort.by(Sort.Direction.DESC, "timestamp"))
-                .stream()
-                .map(FileHistoryDto::fromEntity)
-                .toList();
-    }
+  @GetMapping("/history")
+  @Operation(
+      summary = "Get file history",
+      description = "Returns the history of file operations. Requires authentication.")
+  public List<FileHistoryDto> getHistory() {
+    return fileHistoryRepository.findAll(Sort.by(Sort.Direction.DESC, "timestamp")).stream()
+        .map(FileHistoryDto::fromEntity)
+        .toList();
+  }
 }

--- a/src/main/java/com/javadropbox/javadropbox/controller/LoginController.java
+++ b/src/main/java/com/javadropbox/javadropbox/controller/LoginController.java
@@ -1,5 +1,7 @@
 package com.javadropbox.javadropbox.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -7,20 +9,26 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
+@Tag(name = "Login", description = "Endpoints for login page rendering")
 public class LoginController {
 
-    @GetMapping("/")
-    public String index() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+  @GetMapping("/")
+  @Operation(
+      summary = "Index page",
+      description =
+          "Redirects to dashboard if authenticated, else shows login page. Publicly accessible.")
+  public String index() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
-        if (auth != null && auth.isAuthenticated() && !(auth instanceof AnonymousAuthenticationToken)) {
-            return "redirect:/dashboard";
-        }
-        return "Login";
+    if (auth != null && auth.isAuthenticated() && !(auth instanceof AnonymousAuthenticationToken)) {
+      return "redirect:/dashboard";
     }
+    return "Login";
+  }
 
-    @GetMapping("/login")
-    public String loginPage() {
-        return "Login";
-    }
+  @GetMapping("/login")
+  @Operation(summary = "Login page", description = "Shows the login page. Publicly accessible.")
+  public String loginPage() {
+    return "Login";
+  }
 }

--- a/src/main/java/com/javadropbox/javadropbox/controller/ShareController.java
+++ b/src/main/java/com/javadropbox/javadropbox/controller/ShareController.java
@@ -4,7 +4,13 @@ import com.javadropbox.javadropbox.dto.DownloadableResource;
 import com.javadropbox.javadropbox.service.FileServingService;
 import com.javadropbox.javadropbox.service.ShareTokenService;
 import io.jsonwebtoken.JwtException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -13,75 +19,87 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-import java.io.IOException;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Map;
-
 /**
- * Time-limited share links. {@code POST /api/share} requires the normal session
- * auth (covered by SecurityConfig's default rule). {@code GET /share/{token}} is
- * public &mdash; it is explicitly permitted in SecurityConfig because the whole
- * point is that someone without an account can use the link.
+ * Time-limited share links. {@code POST /api/share} requires the normal session auth (covered by
+ * SecurityConfig's default rule). {@code GET /share/{token}} is public &mdash; it is explicitly
+ * permitted in SecurityConfig because the whole point is that someone without an account can use
+ * the link.
  */
 @RestController
+@Tag(name = "Share", description = "Endpoints for creating and accessing time-limited share links")
 public class ShareController {
 
-    private static final long DEFAULT_EXPIRATION_MINUTES = 24 * 60;
-    private static final long MAX_EXPIRATION_MINUTES = 7 * 24 * 60;
+  private static final long DEFAULT_EXPIRATION_MINUTES = 24 * 60;
+  private static final long MAX_EXPIRATION_MINUTES = 7 * 24 * 60;
 
-    private final ShareTokenService shareTokenService;
-    private final FileServingService fileServingService;
+  private final ShareTokenService shareTokenService;
+  private final FileServingService fileServingService;
 
-    public ShareController(ShareTokenService shareTokenService, FileServingService fileServingService) {
-        this.shareTokenService = shareTokenService;
-        this.fileServingService = fileServingService;
+  public ShareController(
+      ShareTokenService shareTokenService, FileServingService fileServingService) {
+    this.shareTokenService = shareTokenService;
+    this.fileServingService = fileServingService;
+  }
+
+  @PostMapping("/api/share")
+  @Operation(
+      summary = "Create share link",
+      description =
+          "Creates a time-limited share link for a specific path. Requires authentication.")
+  public ResponseEntity<?> createShareLink(
+      @RequestParam String path,
+      @RequestParam(defaultValue = "" + DEFAULT_EXPIRATION_MINUTES) long expirationMinutes,
+      HttpServletRequest request) {
+
+    if (expirationMinutes <= 0 || expirationMinutes > MAX_EXPIRATION_MINUTES) {
+      return ResponseEntity.badRequest()
+          .body(
+              Map.of(
+                  "message", "expirationMinutes must be between 1 and " + MAX_EXPIRATION_MINUTES));
     }
 
-    @PostMapping("/api/share")
-    public ResponseEntity<?> createShareLink(
-            @RequestParam String path,
-            @RequestParam(defaultValue = "" + DEFAULT_EXPIRATION_MINUTES) long expirationMinutes,
-            HttpServletRequest request) {
-
-        if (expirationMinutes <= 0 || expirationMinutes > MAX_EXPIRATION_MINUTES) {
-            return ResponseEntity.badRequest()
-                    .body(Map.of("message", "expirationMinutes must be between 1 and " + MAX_EXPIRATION_MINUTES));
-        }
-
-        if (!fileServingService.pathExists(path)) {
-            return ResponseEntity.notFound().build();
-        }
-
-        String token = shareTokenService.generateToken(path, expirationMinutes);
-        String shareUrl = ServletUriComponentsBuilder.fromRequestUri(request)
-                .replacePath("/share/" + token)
-                .replaceQuery(null)
-                .build()
-                .toUriString();
-
-        return ResponseEntity.ok(Map.of(
-                "url", shareUrl,
-                "expiresAt", Instant.now().plus(Duration.ofMinutes(expirationMinutes)).toString()));
+    if (!fileServingService.pathExists(path)) {
+      return ResponseEntity.notFound().build();
     }
 
-    @GetMapping("/share/{token}")
-    public ResponseEntity<Resource> downloadSharedFile(@PathVariable String token) {
-        String path;
-        try {
-            path = shareTokenService.resolvePath(token);
-        } catch (JwtException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        }
+    String token = shareTokenService.generateToken(path, expirationMinutes);
+    String shareUrl =
+        ServletUriComponentsBuilder.fromRequestUri(request)
+            .replacePath("/share/" + token)
+            .replaceQuery(null)
+            .build()
+            .toUriString();
 
-        try {
-            DownloadableResource downloadable = fileServingService.getResourceForPath(path);
-            return ResponseEntity.ok()
-                    .contentType(MediaType.parseMediaType(downloadable.contentType()))
-                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + downloadable.filename() + "\"")
-                    .body(downloadable.resource());
-        } catch (IOException e) {
-            return ResponseEntity.notFound().build();
-        }
+    return ResponseEntity.ok(
+        Map.of(
+            "url",
+            shareUrl,
+            "expiresAt",
+            Instant.now().plus(Duration.ofMinutes(expirationMinutes)).toString()));
+  }
+
+  @GetMapping("/share/{token}")
+  @Operation(
+      summary = "Download shared file",
+      description = "Downloads a file using a share token. Publicly accessible.")
+  public ResponseEntity<Resource> downloadSharedFile(@PathVariable String token) {
+    String path;
+    try {
+      path = shareTokenService.resolvePath(token);
+    } catch (JwtException e) {
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
     }
+
+    try {
+      DownloadableResource downloadable = fileServingService.getResourceForPath(path);
+      return ResponseEntity.ok()
+          .contentType(MediaType.parseMediaType(downloadable.contentType()))
+          .header(
+              HttpHeaders.CONTENT_DISPOSITION,
+              "attachment; filename=\"" + downloadable.filename() + "\"")
+          .body(downloadable.resource());
+    } catch (IOException e) {
+      return ResponseEntity.notFound().build();
+    }
+  }
 }

--- a/src/main/java/com/javadropbox/javadropbox/controller/WebController.java
+++ b/src/main/java/com/javadropbox/javadropbox/controller/WebController.java
@@ -4,7 +4,13 @@ import com.javadropbox.javadropbox.dto.DownloadableResource;
 import com.javadropbox.javadropbox.dto.FileTreeNode;
 import com.javadropbox.javadropbox.service.AuthService;
 import com.javadropbox.javadropbox.service.FileServingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -15,181 +21,199 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /**
- * WebController handles HTTP requests for the Java Dropbox application.
- * It provides endpoints for login, dashboard navigation, file management, and
- * directory information.
+ * WebController handles HTTP requests for the Java Dropbox application. It provides endpoints for
+ * login, dashboard navigation, file management, and directory information.
  */
 @Controller
+@Tag(name = "Web", description = "Endpoints for file management, directory info, and setup")
 public class WebController {
 
-    @Autowired
-    private FileServingService fileServingService;
-    @Autowired
-    private AuthService authService;
+  @Autowired private FileServingService fileServingService;
+  @Autowired private AuthService authService;
 
-    /**
-     * Handles login form submission.
-     *
-     * @param username           the username entered by the user
-     * @param password           the password entered by the user
-     * @param request            the HTTP servlet request
-     * @param redirectAttributes attributes for redirect scenarios
-     * @return redirect to dashboard on successful login, otherwise redirect to
-     *         login page with error
-     */
-    // @PostMapping("/login")
-    // public String handleLogin(@RequestParam String username,
-    // @RequestParam String password,
-    // HttpServletRequest request,
-    // RedirectAttributes redirectAttributes) {
-    //
-    // if (authService.authenticate(username, password)) {
-    // // On successful login, create a session
-    // HttpSession session = request.getSession(true);
-    // session.setAttribute("user", username);
-    //
-    // redirectAttributes.addAttribute("user", username);
-    // return "redirect:/dashboard";
-    // } else {
-    // redirectAttributes.addAttribute("error", "Invalid username or password");
-    // return "redirect:/login.html";
-    // }
-    // }
+  /**
+   * Handles login form submission.
+   *
+   * @param username the username entered by the user
+   * @param password the password entered by the user
+   * @param request the HTTP servlet request
+   * @param redirectAttributes attributes for redirect scenarios
+   * @return redirect to dashboard on successful login, otherwise redirect to login page with error
+   */
+  // @PostMapping("/login")
+  // public String handleLogin(@RequestParam String username,
+  // @RequestParam String password,
+  // HttpServletRequest request,
+  // RedirectAttributes redirectAttributes) {
+  //
+  // if (authService.authenticate(username, password)) {
+  // // On successful login, create a session
+  // HttpSession session = request.getSession(true);
+  // session.setAttribute("user", username);
+  //
+  // redirectAttributes.addAttribute("user", username);
+  // return "redirect:/dashboard";
+  // } else {
+  // redirectAttributes.addAttribute("error", "Invalid username or password");
+  // return "redirect:/login.html";
+  // }
+  // }
 
-    /**
-     * Renders the dashboard page with user and directory info.
-     * 
-     * @param principal the user logging in
-     * @param model     the model to pass attributes to the view
-     * @return the dashboard view
-     */
-    /**
-     * API endpoint to get directory information.
-     * 
-     * @return a map containing path, existence, readability, and writability of the
-     *         directory
-     */
-    @GetMapping("/api/directory-info")
-    @ResponseBody
-    public ResponseEntity<Map<String, Object>> getDirectoryInfo() {
-        Map<String, Object> info = new HashMap<>();
-        info.put("path", fileServingService.getServingDirectory());
-        info.put("exists", fileServingService.isValidDirectory());
-        info.put("readable", fileServingService.canRead());
-        info.put("writable", fileServingService.canWrite());
+  /**
+   * Renders the dashboard page with user and directory info.
+   *
+   * @param principal the user logging in
+   * @param model the model to pass attributes to the view
+   * @return the dashboard view
+   */
+  /**
+   * API endpoint to get directory information.
+   *
+   * @return a map containing path, existence, readability, and writability of the directory
+   */
+  @GetMapping("/api/directory-info")
+  @ResponseBody
+  @Operation(
+      summary = "Get directory info",
+      description = "Returns information about the root directory. Requires authentication.")
+  public ResponseEntity<Map<String, Object>> getDirectoryInfo() {
+    Map<String, Object> info = new HashMap<>();
+    info.put("path", fileServingService.getServingDirectory());
+    info.put("exists", fileServingService.isValidDirectory());
+    info.put("readable", fileServingService.canRead());
+    info.put("writable", fileServingService.canWrite());
 
-        return ResponseEntity.ok(info);
+    return ResponseEntity.ok(info);
+  }
+
+  /**
+   * API endpoint to get the list of files and directories.
+   *
+   * @return a JSON array of file tree nodes
+   */
+  @GetMapping("/api/files")
+  @ResponseBody
+  @Operation(
+      summary = "Get file tree",
+      description =
+          "Returns a hierarchical tree of all files and directories. Requires authentication.")
+  public ResponseEntity<List<FileTreeNode>> getFileTree(HttpSession session) {
+    List<FileTreeNode> tree = fileServingService.getDirectoryTree();
+    return ResponseEntity.ok(tree);
+  }
+
+  /**
+   * API endpoint to download a file or folder.
+   *
+   * @param path the path to the file or folder
+   * @return the resource to download, or 404 if not found
+   */
+  @GetMapping("/api/download")
+  @Operation(
+      summary = "Download a file or folder",
+      description =
+          "Downloads the file or folder at the specified path. Requires authentication. Path is validated for security.")
+  public ResponseEntity<Resource> downloadFileOrFolder(
+      @RequestParam String path, HttpSession session) {
+    try {
+      DownloadableResource downloadable = fileServingService.getResourceForPath(path);
+
+      return ResponseEntity.ok()
+          .contentType(MediaType.parseMediaType(downloadable.contentType()))
+          .header(
+              HttpHeaders.CONTENT_DISPOSITION,
+              "attachment; filename=\"" + downloadable.filename() + "\"")
+          .body(downloadable.resource());
+
+    } catch (IOException e) {
+      // E.g., file not found or security violation
+      System.err.println("Error processing download request: " + e.getMessage());
+      return ResponseEntity.notFound().build();
     }
+  }
 
-    /**
-     * API endpoint to get the list of files and directories.
-     * 
-     * @return a JSON array of file tree nodes
-     */
-    @GetMapping("/api/files")
-    @ResponseBody
-    public ResponseEntity<List<FileTreeNode>> getFileTree(HttpSession session) {
-        List<FileTreeNode> tree = fileServingService.getDirectoryTree();
-        return ResponseEntity.ok(tree);
+  /**
+   * API endpoint to upload files.
+   *
+   * @param files the files to upload
+   * @param path the target directory path
+   * @return a message indicating success or failure
+   */
+  @PostMapping("/api/upload")
+  @Operation(
+      summary = "Upload files",
+      description =
+          "Uploads one or more files to the specified directory path. Requires authentication.")
+  public ResponseEntity<Map<String, String>> uploadFiles(
+      @RequestParam("files") MultipartFile[] files,
+      @RequestParam(value = "path", defaultValue = "") String path,
+      HttpSession session) {
+
+    try {
+      fileServingService.saveUploadedFiles(files, path);
+      return ResponseEntity.ok(Map.of("message", "Files uploaded successfully!"));
+    } catch (IOException e) {
+      System.err.println("File upload error: " + e.getMessage());
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .body(Map.of("message", "Error uploading files: " + e.getMessage()));
     }
+  }
 
-    /**
-     * API endpoint to download a file or folder.
-     * 
-     * @param path the path to the file or folder
-     * @return the resource to download, or 404 if not found
-     */
-    @GetMapping("/api/download")
-    public ResponseEntity<Resource> downloadFileOrFolder(@RequestParam String path, HttpSession session) {
-        try {
-            DownloadableResource downloadable = fileServingService.getResourceForPath(path);
-
-            return ResponseEntity.ok()
-                    .contentType(MediaType.parseMediaType(downloadable.contentType()))
-                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + downloadable.filename() + "\"")
-                    .body(downloadable.resource());
-
-        } catch (IOException e) {
-            // E.g., file not found or security violation
-            System.err.println("Error processing download request: " + e.getMessage());
-            return ResponseEntity.notFound().build();
-        }
+  /**
+   * API endpoint to delete a file or folder.
+   *
+   * @param path the path to the item to delete
+   * @return a message indicating success or failure
+   */
+  @DeleteMapping("/api/delete")
+  @Operation(
+      summary = "Delete an item",
+      description = "Deletes the file or folder at the specified path. Requires authentication.")
+  public ResponseEntity<Map<String, String>> deleteItem(
+      @RequestParam String path, HttpSession session) {
+    try {
+      fileServingService.deleteItem(path);
+      return ResponseEntity.ok(Map.of("message", "Item deleted successfully: " + path));
+    } catch (IOException e) {
+      System.err.println("Error deleting item: " + e.getMessage());
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .body(Map.of("message", "Could not delete item: " + e.getMessage()));
     }
+  }
 
-    /**
-     * API endpoint to upload files.
-     * 
-     * @param files the files to upload
-     * @param path  the target directory path
-     * @return a message indicating success or failure
-     */
-    @PostMapping("/api/upload")
-    public ResponseEntity<Map<String, String>> uploadFiles(
-            @RequestParam("files") MultipartFile[] files,
-            @RequestParam(value = "path", defaultValue = "") String path,
-            HttpSession session) {
-
-        try {
-            fileServingService.saveUploadedFiles(files, path);
-            return ResponseEntity.ok(Map.of("message", "Files uploaded successfully!"));
-        } catch (IOException e) {
-            System.err.println("File upload error: " + e.getMessage());
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(Map.of("message", "Error uploading files: " + e.getMessage()));
-        }
+  @PostMapping("/setup")
+  @Operation(
+      summary = "Initial setup",
+      description =
+          "Creates the initial admin user. Allowed without authentication if setup is required.")
+  public ResponseEntity<?> processSetup(
+      @RequestParam String username, @RequestParam String password) {
+    if (username == null || username.trim().isEmpty()) {
+      return ResponseEntity.badRequest().body(Map.of("error", "Username required"));
     }
-
-    /**
-     * API endpoint to delete a file or folder.
-     * 
-     * @param path the path to the item to delete
-     * @return a message indicating success or failure
-     */
-    @DeleteMapping("/api/delete")
-    public ResponseEntity<Map<String, String>> deleteItem(@RequestParam String path, HttpSession session) {
-        try {
-            fileServingService.deleteItem(path);
-            return ResponseEntity.ok(Map.of("message", "Item deleted successfully: " + path));
-        } catch (IOException e) {
-            System.err.println("Error deleting item: " + e.getMessage());
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(Map.of("message", "Could not delete item: " + e.getMessage()));
-        }
+    if (password == null || password.trim().isEmpty()) {
+      return ResponseEntity.badRequest().body(Map.of("error", "Password required"));
     }
-
-    @PostMapping("/setup")
-    public ResponseEntity<?> processSetup(@RequestParam String username, @RequestParam String password) {
-        if (username == null || username.trim().isEmpty()) {
-            return ResponseEntity.badRequest().body(Map.of("error", "Username required"));
-        }
-        if (password == null || password.trim().isEmpty()) {
-            return ResponseEntity.badRequest().body(Map.of("error", "Password required"));
-        }
-        if (authService.isSetupRequired()) {
-            authService.setupUser(username, password);
-            return ResponseEntity.ok(Map.of("message", "Setup successful"));
-        }
-        return ResponseEntity.badRequest().body(Map.of("error", "Setup already completed"));
+    if (authService.isSetupRequired()) {
+      authService.setupUser(username, password);
+      return ResponseEntity.ok(Map.of("message", "Setup successful"));
     }
+    return ResponseEntity.badRequest().body(Map.of("error", "Setup already completed"));
+  }
 
-    @PostMapping("/api/create-directory")
-    public ResponseEntity<Map<String, String>> createDirectory(
-            @RequestParam String path,
-            @RequestParam String name,
-            HttpSession session) {
-        try {
-            fileServingService.createDirectory(path, name);
-            return ResponseEntity.ok(Map.of("message", "Directory created successfully: " + name));
-        } catch (IOException e) {
-            System.err.println("Error creating directory: " + e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(Map.of("message", e.getMessage()));
-        }
+  @PostMapping("/api/create-directory")
+  @Operation(
+      summary = "Create directory",
+      description = "Creates a new directory at the specified path. Requires authentication.")
+  public ResponseEntity<Map<String, String>> createDirectory(
+      @RequestParam String path, @RequestParam String name, HttpSession session) {
+    try {
+      fileServingService.createDirectory(path, name);
+      return ResponseEntity.ok(Map.of("message", "Directory created successfully: " + name));
+    } catch (IOException e) {
+      System.err.println("Error creating directory: " + e.getMessage());
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("message", e.getMessage()));
     }
+  }
 }

--- a/src/test/java/com/javadropbox/javadropbox/SwaggerIntegrationTests.java
+++ b/src/test/java/com/javadropbox/javadropbox/SwaggerIntegrationTests.java
@@ -1,0 +1,106 @@
+package com.javadropbox.javadropbox;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.javadropbox.javadropbox.model.User;
+import com.javadropbox.javadropbox.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {"app.setup.filter.enabled=true"})
+@DisplayName("Swagger and OpenAPI Integration Tests")
+class SwaggerIntegrationTests {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Autowired private UserRepository userRepository;
+
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  @AfterEach
+  void tearDown() {
+    userRepository.deleteAll();
+  }
+
+  private void completeSetup() {
+    if (userRepository.count() == 0) {
+      userRepository.save(new User("testadmin", passwordEncoder.encode("password"), "ROLE_ADMIN"));
+    }
+  }
+
+  @Test
+  @DisplayName("Swagger UI is reachable before setup is completed")
+  void swaggerUiReachableBeforeSetup() throws Exception {
+    // No user exists, so SetupFilter treats this as a fresh install and redirects
+    // everything outside its allowlist to /setup. The docs must not be swept up in that.
+    mockMvc
+        .perform(get("/swagger-ui.html"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("/swagger-ui/index.html"));
+
+    mockMvc
+        .perform(get("/swagger-ui/index.html"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("Swagger UI")));
+  }
+
+  @Test
+  @DisplayName("OpenAPI JSON docs are reachable before setup is completed")
+  void openApiDocsReachableBeforeSetup() throws Exception {
+    mockMvc
+        .perform(get("/v3/api-docs"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("\"openapi\"")));
+  }
+
+  @Test
+  @DisplayName("Swagger UI is reachable without authentication after setup")
+  void swaggerUiReachableWithoutAuthAfterSetup() throws Exception {
+    completeSetup();
+
+    mockMvc
+        .perform(get("/swagger-ui/index.html"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("Swagger UI")));
+
+    mockMvc.perform(get("/v3/api-docs")).andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("OpenAPI spec documents every controller and its endpoints")
+  void openApiSpecDocumentsAllEndpoints() throws Exception {
+    mockMvc
+        .perform(get("/v3/api-docs"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("\"name\":\"Web\"")))
+        .andExpect(content().string(containsString("\"name\":\"File Versions\"")))
+        .andExpect(content().string(containsString("\"name\":\"History\"")))
+        .andExpect(content().string(containsString("\"name\":\"Login\"")))
+        .andExpect(content().string(containsString("\"name\":\"Share\"")))
+        .andExpect(content().string(containsString("\"/api/files\"")))
+        .andExpect(content().string(containsString("\"/api/upload\"")))
+        .andExpect(content().string(containsString("\"/api/download\"")))
+        .andExpect(content().string(containsString("\"/api/delete\"")))
+        .andExpect(content().string(containsString("\"/api/create-directory\"")))
+        .andExpect(content().string(containsString("\"/api/directory-info\"")))
+        .andExpect(content().string(containsString("\"/api/history\"")))
+        .andExpect(content().string(containsString("\"/api/share\"")))
+        .andExpect(content().string(containsString("\"/share/{token}\"")))
+        .andExpect(content().string(containsString("\"/api/files/{fileId}/versions\"")))
+        .andExpect(content().string(containsString("\"/setup\"")))
+        .andExpect(content().string(containsString("\"/login\"")));
+  }
+}


### PR DESCRIPTION
## Summary
Documents the full REST API with OpenAPI 3 — closes #53.


- Adds `springdoc-openapi-starter-webmvc-ui` 2.8.5 (compatible with Spring Boot 3.5); spec served at `/v3/api-docs`, UI at `/swagger-ui.html`
- `@Tag`/`@Operation` on all five controllers (WebController, FileVersionController, HistoryApi, LoginController, ShareController) — 14 endpoints, each with a summary noting its purpose and auth requirement
- Permits `/swagger-ui/**` and `/v3/api-docs/**` in SecurityConfig, following the existing `/setup`, `/login`, `/share/**` pattern, with a comment saying why
- Exempts those same paths in `SetupFilter`, so the docs are reachable on a fresh install before the first admin user exists. SecurityConfig alone is not enough here: `SetupFilter` runs ahead of Spring Security and redirects everything outside its own allowlist to `/setup`, so without this the UI 302s to `/setup` on a fresh clone
- README API Reference now links the live UI as the interactive alternative to the static table

The `SetupFilter` exemption matches on exact paths (`/swagger-ui.html`, `/v3/api-docs`) plus trailing-slash prefixes, so it does not open a prefix-matching hole — `/v3/api-docsEVIL` and `/swagger-ui-evil` still redirect to `/setup`.

## Test plan
- [x] `./gradlew build` and `./gradlew test` pass (31 tests, 0 failures), including 4 new integration tests in `SwaggerIntegrationTests`
- [x] New tests run with `app.setup.filter.enabled=true`, mirroring `ShareLinkIntegrationTests`, and cover both the fresh-install and post-setup states; one pins all 5 tags and 14 paths so a controller losing its annotations fails the build
- [x] Confirmed the tests fail without the `SetupFilter` change (3 of 4 fail), so they actually guard the behavior
- [x] Manually verified against real PostgreSQL, existing DB: `/swagger-ui.html` → 302 → `/swagger-ui/index.html` 200, `/v3/api-docs` and `/v3/api-docs/swagger-config` 200, all 14 endpoints listed with summaries
- [x] Manually verified on a throwaway empty database (fresh install, 0 users): docs reachable, while `/api/files`, `/api/history`, `/login`, `/` and `/share/...` all still redirect to `/setup` — setup gate intact
